### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path
     else
-      redirect_to root_path
+      render :show
     end
   end
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move, only: [:show, :edit, :update]
-  before_action :prohibit, only: [:edit, :update]
+  before_action :move, only: [:show, :edit, :update, :destroy]
+  before_action :prohibit, only: [:edit, :update, :destroy]
+
+  
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -34,8 +36,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def destroy
-  # end
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
   
 
   private
@@ -49,7 +56,7 @@ class ItemsController < ApplicationController
   end
 
   def prohibit
-    redirect_to root_path unless current_user.id == @item.user_id
+      redirect_to root_path unless current_user.id == @item.user_id
   end
 
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,7 +33,7 @@
           <% if current_user== @item.user %>
             <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>
-            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+            <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
           <% else %>
             <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [ :index, :create, :new, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
What
商品の削除機能の実装
Why
ユーザーが出品した商品情報を削除するため。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/e1a7d01c2e2252494a07a663b339db2d